### PR TITLE
make newly created event appear on /ManageEvents page right away

### DIFF
--- a/socialtours/src/actions/eventActions.js
+++ b/socialtours/src/actions/eventActions.js
@@ -148,7 +148,7 @@ export const deleteEvent = eventID => async dispatch => {
 		event.status === 200
 			? dispatch({
 					type: types.DELETE_EVENT_SUCCESS,
-					payload: events
+					payload: events.data
 			  })
 			: dispatch({
 					type: types.DELETE_EVENT_FAILED

--- a/socialtours/src/actions/eventActions.js
+++ b/socialtours/src/actions/eventActions.js
@@ -93,10 +93,11 @@ export const postEvent = event => async dispatch => {
 	}); //greg
 	try {
 		const newEvent = await axios.post(API_ENDPOINT + `/api/events`, event);
-		newEvent.status === 200
+		const events = await axios.get(API_ENDPOINT + `/api/events/`);
+		newEvent.status === 201 && events.status === 200
 			? dispatch({
 					type: types.POST_EVENT_SUCCESS,
-					payload: newEvent.data
+					payload: events.data
 			  })
 			: dispatch({
 					type: types.POST_EVENT_FAILED

--- a/socialtours/src/reducers/eventReducer.js
+++ b/socialtours/src/reducers/eventReducer.js
@@ -101,7 +101,7 @@ const eventReducer = (state = initialState, action) => {
 			return {
 				...state,
 				deletingEvent: false,
-				events: action.payload.data
+				events: action.payload
 			};
 		case DELETE_EVENT_FAILURE:
 			console.log("DELETE EVENT FAILURE: ", action.payload);


### PR DESCRIPTION
fix is in first commit. second commit is just refactoring the DELETE_EVENT_SUCCESS action

@mjenkins9605 this should be pretty straighforward to review. the fix is essentially copying what Louis did for the `deleteEvent` in `eventActions.js ` to grab all the events